### PR TITLE
Fix unpaired closing curly braces

### DIFF
--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -570,8 +570,6 @@ function generateUnitXmlTable(unit_id, unit_stats, color)
                     }
                 }
             }
-        }
-    }
 end
 
 function generateUnitAbilitiesXmlTable(unit_id, unit_stats)


### PR DESCRIPTION
Some curly braces were left alone over previous commits, making Lua reject the code. This commit fixes that.